### PR TITLE
Add extended actions to Number Reservation resource

### DIFF
--- a/examples/number_reservation.py
+++ b/examples/number_reservation.py
@@ -6,16 +6,27 @@ import telnyx
 
 telnyx.api_key = os.environ.get("TELNYX_SECRET_KEY")
 
+# For this demo you might want to have a valid number to reserve
+# You can search for a number using https://portaldev.telnyx.com; OR
+# using telnyx.AvailablePhoneNumber
+_telephone_number = ""
+
 print("Listing out reservations...")
 
 list_resp = telnyx.NumberReservation.list()
 
-print("Success: %r" % list_resp)
+print("Success: {}".format(list_resp))
 
 print("Attempting to create a number reservation...")
 
 create_resp = telnyx.NumberReservation.create(
-    phone_numbers=[{"phone_number": "+13122708615"}]
+    phone_numbers=[{"phone_number": _telephone_number}]
 )
 
-print("Success: %r" % create_resp)
+print("Success: {}".format(create_resp))
+
+print("Attempting to extend recently created reservation...")
+
+extension = create_resp.extend()
+
+print("Success extending reservation: {}".format(extension))

--- a/telnyx/api_resources/abstract/nested_resource_class_methods.py
+++ b/telnyx/api_resources/abstract/nested_resource_class_methods.py
@@ -17,7 +17,6 @@ def nested_resource_class_methods(resource, path=None, operations=None):
                 quote_plus(id, safe=util.telnyx_valid_id_parts),
                 quote_plus(path, safe="/"),
             )
-
             if nested_id is not None:
                 url += "/%s" % quote_plus(nested_id, safe=util.telnyx_valid_id_parts)
             return url

--- a/telnyx/api_resources/number_reservation.py
+++ b/telnyx/api_resources/number_reservation.py
@@ -4,10 +4,13 @@ from telnyx.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
     UpdateableAPIResource,
+    nested_resource_class_methods,
 )
 
 
-class NumberReservation(
-    CreateableAPIResource, ListableAPIResource, UpdateableAPIResource
-):
+@nested_resource_class_methods("extend", path="actions/extend", operations=["create"])
+class NumberReservation(CreateableAPIResource, ListableAPIResource):
     OBJECT_NAME = "number_reservation"
+
+    def extend(self, **params):
+        return NumberReservation.create_extend(self.id, **params)

--- a/telnyx/api_resources/number_reservation.py
+++ b/telnyx/api_resources/number_reservation.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 from telnyx.api_resources.abstract import (
     CreateableAPIResource,
     ListableAPIResource,
-    UpdateableAPIResource,
     nested_resource_class_methods,
 )
 

--- a/tests/api_resources/test_number_reservation.py
+++ b/tests/api_resources/test_number_reservation.py
@@ -1,9 +1,46 @@
+from __future__ import absolute_import, division, print_function
 import telnyx
 
+NUMBER_RESERVATION_ID = "f7964e2b-a9f9-4eb6-ab16-e570ffc4bc83"
 
-class TestNumberOrder(object):
+
+def create_number_reservation():
+    return telnyx.NumberReservation.create(
+        phone_numbers=[{"phone_number": "+12223334444"}]
+    )
+
+
+class TestNumberReservation(object):
     def test_is_listable(self, request_mock):
         resources = telnyx.NumberReservation.list()
         request_mock.assert_requested("get", "/v2/number_reservations")
         assert isinstance(resources.data, list)
         assert isinstance(resources.data[0], telnyx.NumberReservation)
+
+    def test_is_retrievable(self, request_mock):
+        resources = telnyx.NumberReservation.retrieve(NUMBER_RESERVATION_ID)
+        request_mock.assert_requested(
+            "get", "/v2/number_reservations/{}".format(NUMBER_RESERVATION_ID)
+        )
+        assert isinstance(resources, telnyx.NumberReservation)
+
+    def test_is_creatable(self, request_mock):
+        resource = create_number_reservation()
+        request_mock.assert_requested("post", "/v2/number_reservations")
+        assert isinstance(resource, telnyx.NumberReservation)
+
+    def test_can_call_extend(self, request_mock):
+        resource = create_number_reservation()
+        resource.extend()
+        request_mock.assert_requested(
+            "post", "/v2/number_reservations/%s/actions/extend" % NUMBER_RESERVATION_ID
+        )
+        assert isinstance(resource, telnyx.NumberReservation)
+
+    def test_can_call_reservation_extend(self, request_mock):
+        resource = create_number_reservation()
+        resource.create_extend(NUMBER_RESERVATION_ID)
+        request_mock.assert_requested(
+            "post", "/v2/number_reservations/%s/actions/extend" % NUMBER_RESERVATION_ID
+        )
+        assert isinstance(resource, telnyx.NumberReservation)


### PR DESCRIPTION
This commit introduce .extend() to NumberReservation obj.
Depends on **https://github.com/team-telnyx/telnyx-mock/pull/2** to run tests
#### Usage:
```python
reservation = telnyx.NumberReservation.retrieve(<number_reservation_id>)
reservation.extend()
```