### PR TITLE
Call conference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `tests/conftest.py`.
-    - TELNYX_MOCK_VERSION=0.2.0
+    - TELNYX_MOCK_VERSION=0.3.0
 
 before_install:
   # Unpack and start telnyx-mock so that the test suite can talk to it

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `tests/conftest.py`.
-    - TELNYX_MOCK_VERSION=0.3.0
+    - TELNYX_MOCK_VERSION=0.3.1
 
 before_install:
   # Unpack and start telnyx-mock so that the test suite can talk to it

--- a/telnyx/api_resources/__init__.py
+++ b/telnyx/api_resources/__init__.py
@@ -17,12 +17,14 @@ from telnyx.api_resources.number_order import NumberOrder
 from telnyx.api_resources.number_order_phone_number import NumberOrderPhoneNumber
 from telnyx.api_resources.number_reservation import NumberReservation
 from telnyx.api_resources.call import Call
+from telnyx.api_resources.conference import Conference
 
 
 __all__ = [
     "APIKey",
     "AvailablePhoneNumber",
     "Call",
+    "Conference",
     "Event",
     "ListObject",
     "Message",

--- a/telnyx/api_resources/conference.py
+++ b/telnyx/api_resources/conference.py
@@ -9,7 +9,7 @@ from telnyx.api_resources.abstract import (
 
 @nested_resource_class_methods("join", path="actions/join", operations=["create"])
 @nested_resource_class_methods("mute", path="actions/mute", operations=["create"])
-@nested_resource_class_methods("umute", path="actions/umute", operations=["create"])
+@nested_resource_class_methods("unmute", path="actions/unmute", operations=["create"])
 @nested_resource_class_methods("hold", path="actions/hold", operations=["create"])
 @nested_resource_class_methods("unhold", path="actions/unhold", operations=["create"])
 class Conference(CreateableAPIResource, ListableAPIResource):
@@ -21,8 +21,8 @@ class Conference(CreateableAPIResource, ListableAPIResource):
     def mute(self, **params):
         return Conference.create_mute(self.id, **params)
 
-    def umute(self, **params):
-        return Conference.create_umute(self.id, **params)
+    def unmute(self, **params):
+        return Conference.create_unmute(self.id, **params)
 
     def hold(self, **params):
         return Conference.create_hold(self.id, **params)

--- a/telnyx/api_resources/conference.py
+++ b/telnyx/api_resources/conference.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import, division, print_function
+
+from telnyx.api_resources.abstract import (
+    CreateableAPIResource,
+    ListableAPIResource,
+    nested_resource_class_methods,
+)
+
+
+@nested_resource_class_methods("join", path="actions/join", operations=["create"])
+@nested_resource_class_methods("mute", path="actions/mute", operations=["create"])
+@nested_resource_class_methods("umute", path="actions/umute", operations=["create"])
+@nested_resource_class_methods("hold", path="actions/hold", operations=["create"])
+@nested_resource_class_methods("unhold", path="actions/unhold", operations=["create"])
+class Conference(CreateableAPIResource, ListableAPIResource):
+    OBJECT_NAME = "conference"
+
+    def join(self, **params):
+        return Conference.create_join(self.id, **params)
+
+    def mute(self, **params):
+        return Conference.create_mute(self.id, **params)
+
+    def umute(self, **params):
+        return Conference.create_umute(self.id, **params)
+
+    def hold(self, **params):
+        return Conference.create_hold(self.id, **params)
+
+    def unhold(self, **params):
+        return Conference.create_unhold(self.id, **params)

--- a/telnyx/util.py
+++ b/telnyx/util.py
@@ -143,6 +143,7 @@ def load_object_classes():
         api_resources.NumberOrderPhoneNumber.OBJECT_NAME: api_resources.NumberOrderPhoneNumber,
         api_resources.NumberReservation.OBJECT_NAME: api_resources.NumberReservation,
         api_resources.Call.OBJECT_NAME: api_resources.Call,
+        api_resources.Conference.OBJECT_NAME: api_resources.Conference,
     }
 
 

--- a/tests/api_resources/test_conference.py
+++ b/tests/api_resources/test_conference.py
@@ -1,0 +1,121 @@
+from __future__ import absolute_import, division, print_function
+import telnyx
+
+CONFERENCE_ID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+_call_control_id = "AgDIxmoRX6QMuaIj_uXRXnPAXP0QlNfXczRrZvZakpWxBlpw48KyZQ=="
+
+
+def create_conference():
+    return telnyx.Conference.create(
+        name="Business",
+        call_control_id=_call_control_id,
+        client_state="aGF2ZSBhIG5pY2UgZGF5ID1d",
+        command_id="891510ac-f3e4-11e8-af5b-de00688a4901",
+    )
+
+
+class TestConference(object):
+    def test_is_listable(self, request_mock):
+        resources = telnyx.Conference.list()
+        request_mock.assert_requested("get", "/v2/conferences")
+        assert isinstance(resources.data, list)
+        assert isinstance(resources.data[0], telnyx.Conference)
+
+    def test_is_creatable(self, request_mock):
+        resource = create_conference()
+        request_mock.assert_requested("post", "/v2/conferences")
+        assert isinstance(resource, telnyx.Conference)
+
+    def test_can_call_join(self, request_mock):
+        resource = create_conference()
+        resource.join(call_control_id=_call_control_id)
+        request_mock.assert_requested(
+            "post", "/v2/conferences/%s/actions/join" % CONFERENCE_ID
+        )
+        assert isinstance(resource, telnyx.Conference)
+
+    def test_can_call_create_join(self, request_mock):
+        resource = create_conference()
+        resource.create_join(CONFERENCE_ID, call_control_id=_call_control_id)
+        request_mock.assert_requested(
+            "post", "/v2/conferences/%s/actions/join" % CONFERENCE_ID
+        )
+        assert isinstance(resource, telnyx.Conference)
+
+    def test_can_call_mute(self, request_mock):
+        resource = create_conference()
+        resource.mute(call_control_ids=[_call_control_id])
+        request_mock.assert_requested(
+            "post", "/v2/conferences/%s/actions/mute" % CONFERENCE_ID
+        )
+        assert isinstance(resource, telnyx.Conference)
+
+    def test_can_call_create_mute(self, request_mock):
+        resource = create_conference()
+        resource.create_mute(CONFERENCE_ID, call_control_ids=[_call_control_id])
+        request_mock.assert_requested(
+            "post", "/v2/conferences/%s/actions/mute" % CONFERENCE_ID
+        )
+        assert isinstance(resource, telnyx.Conference)
+
+    def test_can_call_unmute(self, request_mock):
+        resource = create_conference()
+        resource.unmute(call_control_ids=[_call_control_id])
+        request_mock.assert_requested(
+            "post", "/v2/conferences/%s/actions/unmute" % CONFERENCE_ID
+        )
+        assert isinstance(resource, telnyx.Conference)
+
+    def test_can_call_create_unmute(self, request_mock):
+        resource = create_conference()
+        resource.create_unmute(CONFERENCE_ID, call_control_ids=[_call_control_id])
+        request_mock.assert_requested(
+            "post", "/v2/conferences/%s/actions/unmute" % CONFERENCE_ID
+        )
+        assert isinstance(resource, telnyx.Conference)
+
+    def test_can_call_hold(self, request_mock):
+        resource = create_conference()
+        resource.hold(
+            call_control_ids=[_call_control_id],
+            audio_url="http://example.com/message.wav",
+        )
+        request_mock.assert_requested(
+            "post", "/v2/conferences/%s/actions/hold" % CONFERENCE_ID
+        )
+        assert isinstance(resource, telnyx.Conference)
+
+    def test_can_call_create_hold(self, request_mock):
+        resource = create_conference()
+        resource.create_hold(
+            CONFERENCE_ID,
+            call_control_ids=[_call_control_id],
+            audio_url="http://example.com/message.wav",
+        )
+        request_mock.assert_requested(
+            "post", "/v2/conferences/%s/actions/hold" % CONFERENCE_ID
+        )
+        assert isinstance(resource, telnyx.Conference)
+
+    def test_can_call_unhold(self, request_mock):
+        resource = create_conference()
+        resource.unhold(
+            call_control_ids=[_call_control_id],
+            audio_url="http://example.com/message.wav",
+        )
+        request_mock.assert_requested(
+            "post", "/v2/conferences/%s/actions/unhold" % CONFERENCE_ID
+        )
+        assert isinstance(resource, telnyx.Conference)
+
+    def test_can_call_create_unhold(self, request_mock):
+        resource = create_conference()
+        resource.create_unhold(
+            CONFERENCE_ID,
+            call_control_ids=[_call_control_id],
+            audio_url="http://example.com/message.wav",
+        )
+        request_mock.assert_requested(
+            "post", "/v2/conferences/%s/actions/unhold" % CONFERENCE_ID
+        )
+        assert isinstance(resource, telnyx.Conference)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from tests.telnyx_mock import TelnyxMock
 
 
 # When changing this number, don't forget to change it in `.travis.yml` too.
-MOCK_MINIMUM_VERSION = "0.2.0"
+MOCK_MINIMUM_VERSION = "0.3.0"
 
 # Starts telnyx-mock if an OpenAPI spec override is found in `openapi/`, and
 # otherwise fall back to `TELNYX_MOCK_PORT` or 12111.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from tests.telnyx_mock import TelnyxMock
 
 
 # When changing this number, don't forget to change it in `.travis.yml` too.
-MOCK_MINIMUM_VERSION = "0.3.0"
+MOCK_MINIMUM_VERSION = "0.3.1"
 
 # Starts telnyx-mock if an OpenAPI spec override is found in `openapi/`, and
 # otherwise fall back to `TELNYX_MOCK_PORT` or 12111.


### PR DESCRIPTION
#### Conference Resource
- Create
- List

Actions:
- mute
- unmute
- hold
- unhold

#### Usage:
```python
conference = telnyx.Conference.create(
    name="conference name", call_control_id=<call_control_id>
)
conference.join(call_control_id=<call_control_id>)
conference.mute(call_control_ids=[<call_control_id>, <call_control_id>])
conference.unhold(
        call_control_ids=[<call_control_id>, <call_control_id>],
        audio_url="http://example.com/message.wav",
    )
)
```
This PR depends on https://github.com/team-telnyx/telnyx-mock/pull/3