### PR TITLE
Fix nested objects being overwritten

### DIFF
--- a/telnyx/telnyx_object.py
+++ b/telnyx/telnyx_object.py
@@ -13,7 +13,7 @@ def _compute_diff(current, previous):
         previous = previous or {}
         diff = current.copy()
         for key in set(previous.keys()) - set(diff.keys()):
-            diff[key] = ""
+            diff[key] = previous[key]
         return diff
     return current if current is not None else ""
 

--- a/tests/api_resources/abstract/test_updateable_api_resource.py
+++ b/tests/api_resources/abstract/test_updateable_api_resource.py
@@ -272,7 +272,12 @@ class TestUpdateableAPIResource(object):
             {
                 "baz": "updated",
                 "other": "newval",
-                "nested_object": {"size": "m", "info": "a2", "height": old_nested_object.get('height'), "score": 4},
+                "nested_object": {
+                    "size": "m",
+                    "info": "a2",
+                    "height": old_nested_object.get("height"),
+                    "score": 4,
+                },
             },
             None,
         )


### PR DESCRIPTION
#### The Issue

When users try to update/save (PATCH) nested objects, telnyx-python is overriding any non-given field.
e.g.
```python

my_messaging_profile = telnyx.MessagingProfile.retrieve(<messaging_profile_id>)
print(my_messaging_profile.number_pool_settings)

> <TelnyxObject at 0x7f4ae00ebad0> JSON: {\n  "geomatch": false,\n  "lc_weight": 0.0,\n  "skip_unhealthy": false,\n  "sticky_sender": false,\n  "tf_weight": 0.0\n}
'geomatch':False
'lc_weight':0.0
'skip_unhealthy':False
'sticky_sender':False
'tf_weight':0.0

mess.number_pool_settings = {"geomatch": True}
response = mess.save()
```

When users `.save()` it, all attributes of `number_pool_settings` except `geomatch` will be updated to "" (empty string). [See here](https://github.com/team-telnyx/telnyx-python/compare/number_pool_fix?expand=1#diff-be1e1ae779860248015be609dc7e83c6L16)

### Proposal

Rather than replace values to "" I suggest using the current (not updated) values of the object. In this case, only the given attribute will be updated and all the rest will remain unchanged. [See here](https://github.com/team-telnyx/telnyx-python/compare/number_pool_fix?expand=1#diff-be1e1ae779860248015be609dc7e83c6R16)

For cases where we're upserting things, nothing really change.


