### PR TITLE
PyLint and isort cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ fmtcheck:
 lint:
 	pipenv run tox -e lint
 
+pylintcheck:
+	pipenv run tox -e pylint
+
 dists:
 	rm -rf dist
 	pipenv run python setup.py sdist bdist_wheel

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,8 @@ name = "pypi"
 [packages]
 telnyx = {path = ".", editable = true}
 PyNaCl = "*"
+isort = "*"
+pylint = "*"
 
 [dev-packages]
 pytest = ">=3.4"
@@ -15,7 +17,7 @@ pytest-cov = ">=2.5"
 tox = "*"
 "flake8" = "*"
 coveralls = "*"
-black = {version = "==19.3b0", markers = "python_version >= '3.6'"}
+black = {version = "==19.3b0",markers = "python_version >= '3.6'"}
 twine = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "65b7c53da6eb9503cdfc4410a6dcfdc75671da90138bfd6c786da0770fdf51b4"
+            "sha256": "c535add142556b4ffcd033cd0d5093229c7b75150d04ec9a7a4d6a8a53ed03d6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,13 @@
         ]
     },
     "default": {
+        "astroid": {
+            "hashes": [
+                "sha256:6560e1e1749f68c64a4b5dee4e091fce798d2f0d84ebe638cf0e0585a343acf4",
+                "sha256:b65db1bbaac9f9f4d190199bb8680af6f6f84fd3769a5ea883df8a91fe68b4c4"
+            ],
+            "version": "==2.2.5"
+        },
         "certifi": {
             "hashes": [
                 "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
@@ -70,11 +77,58 @@
             ],
             "version": "==2.8"
         },
+        "isort": {
+            "hashes": [
+                "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
+                "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"
+            ],
+            "index": "pypi",
+            "version": "==4.3.21"
+        },
+        "lazy-object-proxy": {
+            "hashes": [
+                "sha256:159a745e61422217881c4de71f9eafd9d703b93af95618635849fe469a283661",
+                "sha256:23f63c0821cc96a23332e45dfaa83266feff8adc72b9bcaef86c202af765244f",
+                "sha256:3b11be575475db2e8a6e11215f5aa95b9ec14de658628776e10d96fa0b4dac13",
+                "sha256:3f447aff8bc61ca8b42b73304f6a44fa0d915487de144652816f950a3f1ab821",
+                "sha256:4ba73f6089cd9b9478bc0a4fa807b47dbdb8fad1d8f31a0f0a5dbf26a4527a71",
+                "sha256:4f53eadd9932055eac465bd3ca1bd610e4d7141e1278012bd1f28646aebc1d0e",
+                "sha256:64483bd7154580158ea90de5b8e5e6fc29a16a9b4db24f10193f0c1ae3f9d1ea",
+                "sha256:6f72d42b0d04bfee2397aa1862262654b56922c20a9bb66bb76b6f0e5e4f9229",
+                "sha256:7c7f1ec07b227bdc561299fa2328e85000f90179a2f44ea30579d38e037cb3d4",
+                "sha256:7c8b1ba1e15c10b13cad4171cfa77f5bb5ec2580abc5a353907780805ebe158e",
+                "sha256:8559b94b823f85342e10d3d9ca4ba5478168e1ac5658a8a2f18c991ba9c52c20",
+                "sha256:a262c7dfb046f00e12a2bdd1bafaed2408114a89ac414b0af8755c696eb3fc16",
+                "sha256:acce4e3267610c4fdb6632b3886fe3f2f7dd641158a843cf6b6a68e4ce81477b",
+                "sha256:be089bb6b83fac7f29d357b2dc4cf2b8eb8d98fe9d9ff89f9ea6012970a853c7",
+                "sha256:bfab710d859c779f273cc48fb86af38d6e9210f38287df0069a63e40b45a2f5c",
+                "sha256:c10d29019927301d524a22ced72706380de7cfc50f767217485a912b4c8bd82a",
+                "sha256:dd6e2b598849b3d7aee2295ac765a578879830fb8966f70be8cd472e6069932e",
+                "sha256:e408f1eacc0a68fed0c08da45f31d0ebb38079f043328dce69ff133b95c29dc1"
+            ],
+            "version": "==1.4.1"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
         "pycparser": {
             "hashes": [
+                "sha256:22e002bc3db3edfd803de248ddcca51bb94e3a184541ab67288c6087ce29acd0",
                 "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
             ],
             "version": "==2.19"
+        },
+        "pylint": {
+            "hashes": [
+                "sha256:5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09",
+                "sha256:723e3db49555abaf9bf79dc474c6b9e2935ad82230b10c1138a71ea41ac0fff1"
+            ],
+            "index": "pypi",
+            "version": "==2.3.1"
         },
         "pynacl": {
             "hashes": [
@@ -119,12 +173,39 @@
             "editable": true,
             "path": "."
         },
+        "typed-ast": {
+            "hashes": [
+                "sha256:18511a0b3e7922276346bcb47e2ef9f38fb90fd31cb9223eed42c85d1312344e",
+                "sha256:262c247a82d005e43b5b7f69aff746370538e176131c32dda9cb0f324d27141e",
+                "sha256:2b907eb046d049bcd9892e3076c7a6456c93a25bebfe554e931620c90e6a25b0",
+                "sha256:354c16e5babd09f5cb0ee000d54cfa38401d8b8891eefa878ac772f827181a3c",
+                "sha256:4e0b70c6fc4d010f8107726af5fd37921b666f5b31d9331f0bd24ad9a088e631",
+                "sha256:630968c5cdee51a11c05a30453f8cd65e0cc1d2ad0d9192819df9978984529f4",
+                "sha256:66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34",
+                "sha256:71211d26ffd12d63a83e079ff258ac9d56a1376a25bc80b1cdcdf601b855b90b",
+                "sha256:95bd11af7eafc16e829af2d3df510cecfd4387f6453355188342c3e79a2ec87a",
+                "sha256:bc6c7d3fa1325a0c6613512a093bc2a2a15aeec350451cbdf9e1d4bffe3e3233",
+                "sha256:cc34a6f5b426748a507dd5d1de4c1978f2eb5626d51326e43280941206c209e1",
+                "sha256:d755f03c1e4a51e9b24d899561fec4ccaf51f210d52abdf8c07ee2849b212a36",
+                "sha256:d7c45933b1bdfaf9f36c579671fec15d25b06c8398f113dab64c18ed1adda01d",
+                "sha256:d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a",
+                "sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"
+            ],
+            "markers": "implementation_name == 'cpython'",
+            "version": "==1.4.0"
+        },
         "urllib3": {
             "hashes": [
                 "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
                 "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
             ],
             "version": "==1.25.3"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
+            ],
+            "version": "==1.11.2"
         }
     },
     "develop": {

--- a/examples/available_phone_number.py
+++ b/examples/available_phone_number.py
@@ -4,7 +4,6 @@ import os
 
 import telnyx
 
-
 telnyx.api_key = os.environ.get("TELNYX_SECRET_KEY")
 
 print("Attempting to perform a available phone number search...")

--- a/examples/messaging_profile.py
+++ b/examples/messaging_profile.py
@@ -4,7 +4,6 @@ import os
 
 import telnyx
 
-
 telnyx.api_key = os.environ.get("TELNYX_SECRET_KEY")
 
 print("Attempting to create messaging profile...")

--- a/examples/proxy.py
+++ b/examples/proxy.py
@@ -4,7 +4,6 @@ import os
 
 import telnyx
 
-
 telnyx.api_key = os.environ.get("TELNYX_SECRET_KEY")
 
 print("Attempting to create Messaging Profile...")

--- a/examples/webhooks.py
+++ b/examples/webhooks.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
-import telnyx
 from flask import Flask, request
 
+import telnyx
 
 telnyx.api_key = os.environ.get("TELNYX_API_KEY")
 public_key = os.environ.get("TELNYX_PUBLIC_KEY")

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,31 @@
+[Messages Control]
+disable=invalid-name, missing-docstring, bad-continuation, fixme, star-args, redefined-builtin, no-name-in-module
+
+[Basic]
+# Variable names can be 1 to 31 characters long, with lowercase and underscores
+variable-rgx=[a-z_][a-z0-9_]{0,30}$
+# Argument names can be 2 to 31 characters long, with lowercase and underscores
+argument-rgx=[a-z_][a-z0-9_]{1,30}$
+# Method names should be at least 3 characters long
+# and be lowercased with underscores
+method-rgx=([a-z_][a-z0-9_]{2,50}|setUp|tearDown)$
+# Don't require docstrings on tests.
+no-docstring-rgx=((__.*__)|([tT]est.*)|setUp|tearDown)$
+
+[Design]
+max-public-methods=100
+min-public-methods=0
+max-args=6
+
+[Variables]
+dummy-variables-rgx=_
+
+[Typecheck]
+# Disable warnings on the six.moves because pylint doesn't
+# support importing from six.moves yet, see:
+# https://bitbucket.org/logilab/pylint/issue/550/
+ignored-modules=telnyx.six, telnyx.six.moves, _MovedItems
+
+[REPORTS]
+output-format=colorized
+msg-template='[{msg_id} {symbol}] {msg} File: {path}, line {line}, in {obj}'

--- a/pylintrc
+++ b/pylintrc
@@ -24,7 +24,7 @@ dummy-variables-rgx=_
 # Disable warnings on the six.moves because pylint doesn't
 # support importing from six.moves yet, see:
 # https://bitbucket.org/logilab/pylint/issue/550/
-ignored-modules=telnyx.six, telnyx.six.moves, _MovedItems
+ignored-modules=telnyx.six, telnyx.six.moves, _MovedItems, nacl
 
 [REPORTS]
 output-format=colorized

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 import os
 import sys
 from codecs import open
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
 
 

--- a/telnyx/__init__.py
+++ b/telnyx/__init__.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
+from telnyx.api_resources import *  # noqa
+from telnyx.webhook import Webhook, WebhookSignature  # noqa
+
 # Telnyx Python bindings
 # API docs at http://developers.telnyx.com
 
@@ -19,10 +22,6 @@ public_key = os.environ.get("TELNYX_PUBLIC_KEY")
 
 # Set to either 'debug' or 'info', controls console logging
 log = None
-
-from telnyx.api_resources import *  # noqa
-
-from telnyx.webhook import Webhook, WebhookSignature  # noqa
 
 
 __version__ = "1.0.0b2"

--- a/telnyx/__init__.py
+++ b/telnyx/__init__.py
@@ -20,10 +20,8 @@ public_key = os.environ.get("TELNYX_PUBLIC_KEY")
 # Set to either 'debug' or 'info', controls console logging
 log = None
 
-# API resources
 from telnyx.api_resources import *  # noqa
 
-# Webhooks
 from telnyx.webhook import Webhook, WebhookSignature  # noqa
 
 

--- a/telnyx/api_requestor.py
+++ b/telnyx/api_requestor.py
@@ -7,7 +7,7 @@ import platform
 import time
 
 import telnyx
-from telnyx import error, http_client, util, six
+from telnyx import error, http_client, six, util
 from telnyx.multipart_data_generator import MultipartDataGenerator
 from telnyx.six.moves.urllib.parse import urlencode, urlsplit, urlunsplit
 from telnyx.telnyx_response import TelnyxResponse

--- a/telnyx/api_resources/__init__.py
+++ b/telnyx/api_resources/__init__.py
@@ -1,23 +1,22 @@
 from __future__ import absolute_import, division, print_function
 
-# flake8: noqa
-
-from telnyx.api_resources.list_object import ListObject
-
-from telnyx.api_resources.event import Event
-from telnyx.api_resources.api_key import APIKey
-from telnyx.api_resources.message import Message
-from telnyx.api_resources.messaging_profile import MessagingProfile
-from telnyx.api_resources.messaging_phone_number import MessagingPhoneNumber
-from telnyx.api_resources.short_code import ShortCode
 from telnyx.api_resources.alphanumeric_sender_id import AlphanumericSenderId
-from telnyx.api_resources.public_key import PublicKey
+from telnyx.api_resources.api_key import APIKey
 from telnyx.api_resources.available_phone_number import AvailablePhoneNumber
+from telnyx.api_resources.call import Call
+from telnyx.api_resources.conference import Conference
+from telnyx.api_resources.event import Event
+from telnyx.api_resources.list_object import ListObject
+from telnyx.api_resources.message import Message
+from telnyx.api_resources.messaging_phone_number import MessagingPhoneNumber
+from telnyx.api_resources.messaging_profile import MessagingProfile
 from telnyx.api_resources.number_order import NumberOrder
 from telnyx.api_resources.number_order_phone_number import NumberOrderPhoneNumber
 from telnyx.api_resources.number_reservation import NumberReservation
-from telnyx.api_resources.call import Call
-from telnyx.api_resources.conference import Conference
+from telnyx.api_resources.public_key import PublicKey
+from telnyx.api_resources.short_code import ShortCode
+
+# flake8: noqa
 
 
 __all__ = [

--- a/telnyx/api_resources/abstract/__init__.py
+++ b/telnyx/api_resources/abstract/__init__.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
-# flake8: noqa
-
 from telnyx.api_resources.abstract.api_resource import APIResource
-from telnyx.api_resources.abstract.singleton_api_resource import SingletonAPIResource
-
 from telnyx.api_resources.abstract.createable_api_resource import CreateableAPIResource
-from telnyx.api_resources.abstract.updateable_api_resource import UpdateableAPIResource
 from telnyx.api_resources.abstract.deletable_api_resource import DeletableAPIResource
 from telnyx.api_resources.abstract.listable_api_resource import ListableAPIResource
 from telnyx.api_resources.abstract.nested_resource_class_methods import (
     nested_resource_class_methods,
 )
+from telnyx.api_resources.abstract.singleton_api_resource import SingletonAPIResource
+from telnyx.api_resources.abstract.updateable_api_resource import UpdateableAPIResource
+
+# flake8: noqa

--- a/telnyx/api_resources/abstract/api_resource.py
+++ b/telnyx/api_resources/abstract/api_resource.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
-from telnyx import error, util, six
-from telnyx.telnyx_object import TelnyxObject
+from telnyx import error, six, util
 from telnyx.six.moves.urllib.parse import quote_plus
+from telnyx.telnyx_object import TelnyxObject
 
 
 class APIResource(TelnyxObject):

--- a/telnyx/api_resources/abstract/createable_api_resource.py
+++ b/telnyx/api_resources/abstract/createable_api_resource.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-from telnyx.api_resources.abstract.api_resource import APIResource
 from telnyx import api_requestor, util
+from telnyx.api_resources.abstract.api_resource import APIResource
 
 
 class CreateableAPIResource(APIResource):

--- a/telnyx/api_resources/alphanumeric_sender_id.py
+++ b/telnyx/api_resources/alphanumeric_sender_id.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
-from telnyx.api_resources.abstract import CreateableAPIResource
-from telnyx.api_resources.abstract import DeletableAPIResource
-from telnyx.api_resources.abstract import UpdateableAPIResource
-from telnyx.api_resources.abstract import ListableAPIResource
+from telnyx.api_resources.abstract import (
+    CreateableAPIResource,
+    DeletableAPIResource,
+    ListableAPIResource,
+    UpdateableAPIResource,
+)
 
 
 class AlphanumericSenderId(

--- a/telnyx/api_resources/api_key.py
+++ b/telnyx/api_resources/api_key.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
-from telnyx.api_resources.abstract import CreateableAPIResource
-from telnyx.api_resources.abstract import DeletableAPIResource
-from telnyx.api_resources.abstract import ListableAPIResource
+from telnyx.api_resources.abstract import (
+    CreateableAPIResource,
+    DeletableAPIResource,
+    ListableAPIResource,
+)
 
 
 class APIKey(CreateableAPIResource, ListableAPIResource, DeletableAPIResource):

--- a/telnyx/api_resources/list_object.py
+++ b/telnyx/api_resources/list_object.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
 from telnyx import util
-from telnyx.telnyx_object import TelnyxObject
-
 from telnyx.six.moves.urllib.parse import quote_plus
+from telnyx.telnyx_object import TelnyxObject
 
 
 class ListObject(TelnyxObject):

--- a/telnyx/api_resources/messaging_phone_number.py
+++ b/telnyx/api_resources/messaging_phone_number.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from telnyx.api_resources.abstract import UpdateableAPIResource
-from telnyx.api_resources.abstract import ListableAPIResource
+from telnyx.api_resources.abstract import ListableAPIResource, UpdateableAPIResource
 
 
 class MessagingPhoneNumber(ListableAPIResource, UpdateableAPIResource):

--- a/telnyx/api_resources/messaging_profile.py
+++ b/telnyx/api_resources/messaging_profile.py
@@ -1,10 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
-from telnyx.api_resources.abstract import CreateableAPIResource
-from telnyx.api_resources.abstract import DeletableAPIResource
-from telnyx.api_resources.abstract import UpdateableAPIResource
-from telnyx.api_resources.abstract import ListableAPIResource
-from telnyx.api_resources.abstract import nested_resource_class_methods
+from telnyx.api_resources.abstract import (
+    CreateableAPIResource,
+    DeletableAPIResource,
+    ListableAPIResource,
+    UpdateableAPIResource,
+    nested_resource_class_methods,
+)
 
 
 @nested_resource_class_methods("phone_number", operations=["list"])

--- a/telnyx/api_resources/short_code.py
+++ b/telnyx/api_resources/short_code.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from telnyx.api_resources.abstract import UpdateableAPIResource
-from telnyx.api_resources.abstract import ListableAPIResource
+from telnyx.api_resources.abstract import ListableAPIResource, UpdateableAPIResource
 
 
 class ShortCode(ListableAPIResource, UpdateableAPIResource):

--- a/telnyx/http_client.py
+++ b/telnyx/http_client.py
@@ -1,13 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
+import email
+import random
 import sys
 import textwrap
-import warnings
-import email
 import time
-import random
+import warnings
 
-from telnyx import error, util, six
+from telnyx import error, six, util
+from telnyx.six.moves.urllib.parse import urlparse
 
 # - Requests is the preferred HTTP library
 # - Google App Engine has urlfetch
@@ -54,9 +55,6 @@ try:
     from google.appengine.api import urlfetch
 except ImportError:
     urlfetch = None
-
-# proxy support for the pycurl client
-from telnyx.six.moves.urllib.parse import urlparse
 
 
 def new_default_http_client(*args, **kwargs):
@@ -132,7 +130,7 @@ class HTTPClient(object):
                 if response is not None:
                     return response
                 else:
-                    raise connection_error
+                    raise connection_error  # pylint: disable=E0702
 
     def request(self, method, url, headers, post_data=None):
         raise NotImplementedError("HTTPClient subclasses must implement `request`")

--- a/telnyx/multipart_data_generator.py
+++ b/telnyx/multipart_data_generator.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-import random
 import io
+import random
 
 from telnyx import six
 

--- a/telnyx/six.py
+++ b/telnyx/six.py
@@ -18,6 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+#pylint: disable=E,C,W,R
+
 """Utilities for writing code that runs on Python 2 and 3"""
 
 from __future__ import absolute_import
@@ -122,8 +124,7 @@ class MovedModule(_LazyDescr):
 
 
 class _LazyModule(types.ModuleType):
-
-    def __init__(self, name):
+    def __init__(self, name): #pylint: disable=bad-option-value
         super(_LazyModule, self).__init__(name)
         self.__doc__ = self.__class__.__doc__
 
@@ -739,7 +740,7 @@ else:
 
 print_ = getattr(moves.builtins, "print", None)
 if print_ is None:
-    def print_(*args, **kwargs):
+    def print_(*args, **kwargs): #pylint: disable=function-redefined
         """The new-style print function for Python 2.4 and 2.5."""
         fp = kwargs.pop("file", sys.stdout)
         if fp is None:
@@ -795,7 +796,7 @@ if print_ is None:
 if sys.version_info[:2] < (3, 3):
     _print = print_
 
-    def print_(*args, **kwargs):
+    def print_(*args, **kwargs): #pylint: disable=function-redefined
         fp = kwargs.get("file", sys.stdout)
         flush = kwargs.pop("flush", False)
         _print(*args, **kwargs)
@@ -872,6 +873,7 @@ def python_2_unicode_compatible(klass):
 __path__ = []  # required for PEP 302 and PEP 451
 __package__ = __name__  # see PEP 366 @ReservedAssignment
 if globals().get("__spec__") is not None:
+    #pylint: disable=undefined-variable
     __spec__.submodule_search_locations = []  # PEP 451 @UndefinedVariable
 # Remove other six meta path importers, since they cause problems. This can
 # happen if six is removed from sys.modules and then reloaded. (Setuptools does

--- a/telnyx/telnyx_object.py
+++ b/telnyx/telnyx_object.py
@@ -5,7 +5,7 @@ import json
 from copy import deepcopy
 
 import telnyx
-from telnyx import api_requestor, util, six
+from telnyx import api_requestor, six, util
 
 
 def _compute_diff(current, previous):
@@ -35,7 +35,7 @@ def _serialize_list(array, previous):
 
 class TelnyxObject(dict):
     class ReprJSONEncoder(json.JSONEncoder):
-        def default(self, obj):
+        def default(self, obj):  # pylint: disable=method-hidden
             if isinstance(obj, datetime.datetime):
                 return api_requestor._encode_datetime(obj)
             return super(TelnyxObject.ReprJSONEncoder, self).default(obj)

--- a/telnyx/util.py
+++ b/telnyx/util.py
@@ -3,14 +3,13 @@ from __future__ import absolute_import, division, print_function
 import hmac
 import io
 import logging
-import sys
 import os
 import re
+import sys
 
 import telnyx
 from telnyx import six
 from telnyx.six.moves.urllib.parse import parse_qsl
-
 
 telnyx_LOG = os.environ.get("telnyx_LOG")
 

--- a/telnyx/webhook.py
+++ b/telnyx/webhook.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
+import base64
 import json
 import time
-import base64
 
 from nacl.encoding import Base64Encoder
 from nacl.signing import VerifyKey

--- a/tests/api_resources/test_alphanumeric_sender_id.py
+++ b/tests/api_resources/test_alphanumeric_sender_id.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import telnyx
 
-
 TEST_RESOURCE_ID = "123"
 
 

--- a/tests/api_resources/test_conference.py
+++ b/tests/api_resources/test_conference.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function
+
 import telnyx
 
 CONFERENCE_ID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"

--- a/tests/api_resources/test_message.py
+++ b/tests/api_resources/test_message.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import telnyx
 
-
 TEST_MESSAGING_PROFILE_ID = "d120432d-2e77-4583-87f8-1db837cee559"
 TEST_SRC_LONG_CODE = "+13125550100"
 TEST_SRC_ALPHANUMERIC = "Testing 123"

--- a/tests/api_resources/test_messaging_phone_number.py
+++ b/tests/api_resources/test_messaging_phone_number.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import telnyx
 from telnyx.six.moves.urllib.parse import quote_plus
 
-
 TEST_RESOURCE_ID = "+18005554000"
 
 

--- a/tests/api_resources/test_messaging_profile.py
+++ b/tests/api_resources/test_messaging_profile.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import telnyx
 
-
 TEST_RESOURCE_ID = "123"
 
 

--- a/tests/api_resources/test_number_reservation.py
+++ b/tests/api_resources/test_number_reservation.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function
+
 import telnyx
 
 NUMBER_RESERVATION_ID = "f7964e2b-a9f9-4eb6-ab16-e570ffc4bc83"

--- a/tests/api_resources/test_short_code.py
+++ b/tests/api_resources/test_short_code.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import telnyx
 
-
 TEST_RESOURCE_ID = "123"
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,14 +6,12 @@ import sys
 from distutils.version import StrictVersion
 
 import pytest
-
-import telnyx
-from telnyx.six.moves.urllib.request import urlopen
-from telnyx.six.moves.urllib.error import HTTPError
-
 from tests.request_mock import RequestMock
 from tests.telnyx_mock import TelnyxMock
 
+import telnyx
+from telnyx.six.moves.urllib.error import HTTPError
+from telnyx.six.moves.urllib.request import urlopen
 
 # When changing this number, don't forget to change it in `.travis.yml` too.
 MOCK_MINIMUM_VERSION = "0.4.0"

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -6,13 +6,11 @@ import tempfile
 import uuid
 
 import pytest
+from six.moves.urllib.parse import urlsplit
 
 import telnyx
 from telnyx import six
 from telnyx.telnyx_response import TelnyxResponse
-
-from six.moves.urllib.parse import urlsplit
-
 
 VALID_API_METHODS = ("get", "post", "delete")
 

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from telnyx import six, error
+from telnyx import error, six
 
 
 class TestTelnyxError(object):

--- a/tests/test_telnyx_object.py
+++ b/tests/test_telnyx_object.py
@@ -10,7 +10,6 @@ import pytest
 import telnyx
 from telnyx import six
 
-
 SAMPLE_FOO = json.loads(
     """
 {

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -3,12 +3,11 @@ from __future__ import absolute_import, division, print_function
 import base64
 import time
 
-from nacl.signing import SigningKey
-from nacl.encoding import Base64Encoder
 import pytest
+from nacl.encoding import Base64Encoder
+from nacl.signing import SigningKey
 
 import telnyx
-
 
 DUMMY_WEBHOOK_PAYLOAD = b"""{
     "record_type": "event",

--- a/tox.ini
+++ b/tox.ini
@@ -20,11 +20,39 @@ commands = python setup.py test -a "{posargs:-n auto}"
 [testenv:fmt]
 description = run code formatting using black
 basepython = python3.7
-deps = black
-commands = black . {posargs}
+known_first_party = telnyx
+deps =
+    black
+    isort
+commands =
+    isort -rc --atomic . {posargs}
+    black . {posargs}
 
 [testenv:lint]
-description = run static analysis and style check using flake8
+description = run static analysis and style check using flake8, isort and pylint
 basepython = python2.7
-deps = flake8
-commands = python -m flake8 --show-source telnyx tests setup.py {posargs}
+deps =
+    flake8
+    isort
+    pylint
+commands =
+    python -m flake8 --show-source telnyx tests setup.py {posargs}
+    isort -rc telnyx --check
+    pylint telnyx --errors-only
+
+[testenv:pylint]
+description = run static analysis and style check using pylint
+basepython = python2.7
+deps = pylint
+commands =
+    pylint telnyx
+
+
+[isort]
+line_length=88
+multi_line_output=3
+include_trailing_comma=1
+force_grid_wrap = 0
+combine_as_imports = true
+known_first_party = telnyx
+known_localfolder = telnyx


### PR DESCRIPTION
### Lint Cleanup

This pull-request introduces [pylint](https://www.pylint.org/) and [isort](https://pypi.org/project/isort/) clean-ups and uses these tools as part of the CI checks.

#### New commands:
- `make pylintcheck`: Check general pylint warnings

#### Changed commands:
- `make lint`: From now it will also check isort and pylint errors
- `make fmt`: From now it will also format imports using isort
- `make checkfmt`: From now it will also check imports using isort


#### Pylint erros:

**Before:**

```************* Module telnyx.webhook
telnyx/webhook.py:7: [E0401(import-error), ] Unable to import 'nacl.encoding'
telnyx/webhook.py:8: [E0401(import-error), ] Unable to import 'nacl.signing'
************* Module telnyx.util
telnyx/util.py:12: [E0611(no-name-in-module), ] No name 'urllib' in module '_MovedItems'
telnyx/util.py:12: [E0401(import-error), ] Unable to import 'telnyx.six.moves.urllib.parse'
************* Module telnyx.http_client
telnyx/http_client.py:59: [E0611(no-name-in-module), ] No name 'urllib' in module '_MovedItems'
telnyx/http_client.py:59: [E0401(import-error), ] Unable to import 'telnyx.six.moves.urllib.parse'
************* Module telnyx.six
telnyx/six.py:49: [E0602(undefined-variable), ] Undefined variable 'basestring'
telnyx/six.py:50: [E0602(undefined-variable), ] Undefined variable 'long'
telnyx/six.py:51: [E1101(no-member), ] Module 'types' has no 'ClassType' member
telnyx/six.py:52: [E0602(undefined-variable), ] Undefined variable 'unicode'
telnyx/six.py:92: [E1101(no-member), _LazyDescr.__get__] Instance of '_LazyDescr' has no '_resolve' member
telnyx/six.py:564: [E1101(no-member), Iterator.next] Class 'Iterator' has no '__next__' member
telnyx/six.py:653: [E0602(undefined-variable), u] Undefined variable 'unicode'
telnyx/six.py:662: [E1101(no-member), ] Module 'itertools' has no 'imap' member
telnyx/six.py:663: [E0401(import-error), ] Unable to import 'StringIO'
telnyx/six.py:685: [E1101(no-member), ] Instance of '_MovedItems' has no 'builtins' member
telnyx/six.py:740: [E1101(no-member), ] Instance of '_MovedItems' has no 'builtins' member
telnyx/six.py:742: [E0102(function-redefined), print_] function already defined line 740
telnyx/six.py:749: [E0602(undefined-variable), print_.write] Undefined variable 'basestring'
telnyx/six.py:752: [E0602(undefined-variable), print_.write] Undefined variable 'file'
telnyx/six.py:753: [E0602(undefined-variable), print_.write] Undefined variable 'unicode'
telnyx/six.py:763: [E0602(undefined-variable), print_] Undefined variable 'unicode'
telnyx/six.py:769: [E0602(undefined-variable), print_] Undefined variable 'unicode'
telnyx/six.py:777: [E0602(undefined-variable), print_] Undefined variable 'unicode'
telnyx/six.py:781: [E0602(undefined-variable), print_] Undefined variable 'unicode'
telnyx/six.py:782: [E0602(undefined-variable), print_] Undefined variable 'unicode'
telnyx/six.py:798: [E0102(function-redefined), print_] function already defined line 740
************* Module telnyx.telnyx_object
telnyx/telnyx_object.py:38: [E0202(method-hidden), TelnyxObject.ReprJSONEncoder.default] An attribute defined in json.encoder line 158 hides this method
************* Module telnyx.api_requestor
telnyx/api_requestor.py:12: [E0611(no-name-in-module), ] No name 'urllib' in module '_MovedItems'
telnyx/api_requestor.py:12: [E0401(import-error), ] Unable to import 'telnyx.six.moves.urllib.parse'
************* Module telnyx.api_resources.list_object
telnyx/api_resources/list_object.py:6: [E0611(no-name-in-module), ] No name 'urllib' in module '_MovedItems'
telnyx/api_resources/list_object.py:6: [E0401(import-error), ] Unable to import 'telnyx.six.moves.urllib.parse'
************* Module telnyx.api_resources.abstract.api_resource
telnyx/api_resources/abstract/api_resource.py:5: [E0611(no-name-in-module), ] No name 'urllib' in module '_MovedItems'
telnyx/api_resources/abstract/api_resource.py:5: [E0401(import-error), ] Unable to import 'telnyx.six.moves.urllib.parse'
************* Module telnyx.api_resources.abstract.nested_resource_class_methods
telnyx/api_resources/abstract/nested_resource_class_methods.py:4: [E0611(no-name-in-module), ] No name 'urllib' in module '_MovedItems'
telnyx/api_resources/abstract/nested_resource_class_methods.py:4: [E0401(import-error), ] Unable to import 'telnyx.six.moves.urllib.parse'
************* Module telnyx.api_resources.abstract.updateable_api_resource
telnyx/api_resources/abstract/updateable_api_resource.py:5: [E0611(no-name-in-module), ] No name 'urllib' in module '_MovedItems'```
```

**After:**

`No errors.`

#### Code Rating:

**Before:**

`Your code has been rated at 5.44/10 (previous run: 5.39/10, +0.05)`

**After:**

`Your code has been rated at 9.39/10 (previous run: 5.44/10, +3.95)`

This PR also re-formatted all imports (using make fmt).