### PR TITLE
Add support for sending messages using number pool

### DIFF
--- a/telnyx/api_resources/message.py
+++ b/telnyx/api_resources/message.py
@@ -10,6 +10,9 @@ from telnyx.api_resources.abstract import (
 @nested_resource_class_methods(
     "alphanumeric_sender_id", path="alphanumeric_sender_id", operations=["create"]
 )
+@nested_resource_class_methods(
+    "number_pool", path="number_pool", operations=["create"]
+)
 class Message(CreateableAPIResource):
     OBJECT_NAME = "message"
 
@@ -17,3 +20,8 @@ class Message(CreateableAPIResource):
     def send_from_alphanumeric_sender_id(cls, **params):
         params = util.rewrite_reserved_words(params)
         return Message.create_alphanumeric_sender_id(None, **params)
+
+    @classmethod
+    def send_using_number_pool(cls, **params):
+        params = util.rewrite_reserved_words(params)
+        return Message.create_number_pool(None, **params)

--- a/tests/api_resources/test_message.py
+++ b/tests/api_resources/test_message.py
@@ -26,3 +26,12 @@ class TestMessage(object):
         )
         request_mock.assert_requested("post", "/v2/messages/alphanumeric_sender_id")
         assert isinstance(resource, telnyx.Message)
+
+    def test_can_create_number_pool_message(self, request_mock):
+        resource = telnyx.Message.send_using_number_pool(
+            messaging_profile_id=TEST_MESSAGING_PROFILE_ID,
+            to=TEST_DST,
+            text=TEST_MESSAGE_BODY,
+        )
+        request_mock.assert_requested("post", "/v2/messages/number_pool")
+        assert isinstance(resource, telnyx.Message)


### PR DESCRIPTION
The Message resource now has a `send_using_number_pool` method, analogous to the existing `send_from_alphanumeric_sender_id` method.