### PR TITLE
ENGDESK-4618: Rewrite reserved words on nested resource class methods

### DIFF
--- a/telnyx/api_resources/abstract/nested_resource_class_methods.py
+++ b/telnyx/api_resources/abstract/nested_resource_class_methods.py
@@ -33,6 +33,7 @@ def nested_resource_class_methods(
 
         def nested_resource_request(cls, method, url, api_key=None, **params):
             requestor = api_requestor.APIRequestor(api_key)
+            params = util.rewrite_reserved_words(params)
             response, api_key = requestor.request(method, url, params)
             return util.convert_to_telnyx_object(response, api_key)
 

--- a/telnyx/telnyx_object.py
+++ b/telnyx/telnyx_object.py
@@ -238,6 +238,8 @@ class TelnyxObject(dict):
             elif k == "additional_owners" and v is not None:
                 params[k] = _serialize_list(v, previous.get(k, None))
 
+        params = util.rewrite_reserved_words(params)
+
         return params
 
     # This class overrides __setitem__ to throw exceptions on inputs that it

--- a/telnyx/util.py
+++ b/telnyx/util.py
@@ -44,9 +44,15 @@ def _console_log_level():
 
 # Rewrites reserved word keyword arguments
 # This makes Message.create(to="", from_="", text="") possible
-def rewrite_reserved_words(kwargs):
+def rewrite_reserved_words(kwargs, reverse=False):
     reserved = [("from_", "from")]
-    for original, replacement in reserved:
+
+    for i in reserved:
+        if not reverse:
+            original, replacement = i
+        else:
+            replacement, original = i
+
         if kwargs.get(original, None) is not None:
             kwargs[replacement] = kwargs.pop(original)
 
@@ -147,6 +153,7 @@ def convert_to_telnyx_object(resp, api_key=None):
         resp, telnyx.telnyx_object.TelnyxObject
     ):
         resp = resp.copy()
+        resp = rewrite_reserved_words(resp, reverse=True)
         data = resp.get("data", None)
         if data:
             if isinstance(data, list):

--- a/tests/api_resources/abstract/test_nested_resource_class_methods.py
+++ b/tests/api_resources/abstract/test_nested_resource_class_methods.py
@@ -84,3 +84,15 @@ class TestNestedResourceClassMethods(object):
 
         with pytest.raises(ValueError):
             decorator(Foo)
+
+    def test_rewrite_reserved_words(self, request_mock):
+        request_mock.stub_request(
+            "post",
+            "/v2/mainresources/id/nesteds",
+            {"id": "nested_id", "object": "nested", "from": "foo"},
+        )
+        nested_resource = self.MainResource.create_nested("id", from_="foo")
+        request_mock.assert_requested(
+            "post", "/v2/mainresources/id/nesteds", {"from": "foo"}, None
+        )
+        assert nested_resource.from_ == "foo"

--- a/tests/api_resources/abstract/test_updateable_api_resource.py
+++ b/tests/api_resources/abstract/test_updateable_api_resource.py
@@ -14,7 +14,7 @@ class TestUpdateableAPIResource(object):
         request_mock.stub_request(
             "patch",
             "/v2/myupdateables/myid",
-            {"id": "myid", "thats": "it"},
+            {"id": "myid", "thats": "it", "from": "outside"},
             rheaders={"request-id": "req_id"},
         )
 
@@ -23,6 +23,7 @@ class TestUpdateableAPIResource(object):
                 "id": "myid",
                 "foo": "bar",
                 "baz": "boz",
+                "from": "inside",
                 "nested_object": {"size": "l", "score": 4, "height": 10},
             },
             "mykey",
@@ -308,3 +309,14 @@ class TestUpdateableAPIResource(object):
         v = self.MyUpdateable.construct_from({"id": "123", "foo": "bar"}, "mykey")
 
         assert self.MyUpdateable.save_method(v) == "patch"
+
+    def test_save_reserved_word(self, request_mock, obj):
+        obj.from_ = "outside"
+
+        self.checkSave(obj)
+
+        request_mock.assert_requested(
+            "patch", "/v2/myupdateables/myid", {"from": "outside"}, None
+        )
+
+        assert obj.from_ == "outside"


### PR DESCRIPTION
`nested_resource_class_methods` methods use their own API requestor
instance to make the HTTP request. It was forgotten to rewrite the
reserved words before using them in this request.

When testing this change, I noticed we didn't seem to handle the
returned response at all. If the API returned an response body with
`{"from": "foo"}`, the attribute would be initialised with `obj.from =
"foo"`. This meant future updates would fail as attempting to set
`obj.from` would result in an error due to the reserved keyword. You
would have to use `setattr(obj, "from", "baz")`.

I've fixed this by ensuring reserved words are rewritten not only before
sending them to the API but also when handling the response.

This means you can now do:

    obj = BaseClass.nested_resource.create(from_="foo")
    obj.from_ = "baz"
    obj.save()

    assert obj.from_ == "baz"