### PR TITLE
Bump telnyx-mock version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ cache:
 env:
   global:
     # If changing this number, please also change it in `tests/conftest.py`.
-    - TELNYX_MOCK_VERSION=0.8.8
+    - TELNYX_MOCK_VERSION=0.8.10
 
 before_install:
   # Unpack and start telnyx-mock so that the test suite can talk to it

--- a/tests/api_resources/test_call_control_application.py
+++ b/tests/api_resources/test_call_control_application.py
@@ -21,7 +21,9 @@ class TestCallControlApplication(object):
 
     def test_is_creatable(self, request_mock):
         resource = telnyx.CallControlApplication.create(
-            connection_name="foo", webhook_event_url="http://foo.com"
+            connection_name="foo",
+            webhook_event_url="http://foo.com",
+            application_name="foo",
         )
         request_mock.assert_requested("post", "/v2/call_control_applications")
         assert isinstance(resource, telnyx.CallControlApplication)
@@ -32,6 +34,7 @@ class TestCallControlApplication(object):
         )
         call_control_application.connection_name = "foo"
         call_control_application.webhook_event_url = "http://foo.com"
+        call_control_application.application_name = "foo"
         resource = call_control_application.save()
         request_mock.assert_requested(
             "patch", "/v2/call_control_applications/%s" % TEST_RESOURCE_ID
@@ -41,7 +44,10 @@ class TestCallControlApplication(object):
 
     def test_is_modifiable(self, request_mock):
         resource = telnyx.CallControlApplication.modify(
-            TEST_RESOURCE_ID, connection_name="foo", webhook_event_url="http://foo.com"
+            TEST_RESOURCE_ID,
+            connection_name="foo",
+            webhook_event_url="http://foo.com",
+            application_name="foo",
         )
         request_mock.assert_requested(
             "patch", "/v2/call_control_applications/%s" % TEST_RESOURCE_ID

--- a/tests/api_resources/test_detail_records_report.py
+++ b/tests/api_resources/test_detail_records_report.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import telnyx
 
-TEST_RESOURCE_ID = "123"
+TEST_RESOURCE_ID = "6a09cdc3-8948-47f0-aa62-74ac943d6c58"
 
 
 class TestDetailRecordsReport(object):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from telnyx.six.moves.urllib.error import HTTPError
 from telnyx.six.moves.urllib.request import urlopen
 
 # When changing this number, don't forget to change it in `.travis.yml` too.
-MOCK_MINIMUM_VERSION = "0.8.8"
+MOCK_MINIMUM_VERSION = "0.8.10"
 
 # Starts telnyx-mock if an OpenAPI spec override is found in `openapi/`, and
 # otherwise fall back to `TELNYX_MOCK_PORT` or 12111.


### PR DESCRIPTION
Fix /v2/call_control_applications

Endpoint now requires an `application_name`