### PR TITLE
Fix: Make nested_id optional for PUT operations in client_state_update

### DIFF
--- a/telnyx/api_resources/abstract/nested_resource_class_methods.py
+++ b/telnyx/api_resources/abstract/nested_resource_class_methods.py
@@ -101,11 +101,11 @@ def nested_resource_class_methods(
 
             elif operation == "put":
 
-                def update_nested_resource(cls, id, nested_id, **params):
+                def update_nested_resource(cls, id, nested_id=None, **params):
                     url = getattr(cls, resource_url_method)(id, nested_id)
                     return getattr(cls, resource_request_method)("put", url, **params)
 
-                update_method = "update_%s" % resource
+                update_method = "put_%s" % resource
                 setattr(cls, update_method, classmethod(update_nested_resource))
 
             else:


### PR DESCRIPTION
# Fix Client State Update Method in Python SDK

## Description
The Python SDK's `client_state_update` method was failing when trying to update a call's client state. The issue stemmed from the nested resource class methods decorator requiring a `nested_id` parameter for PUT operations, which isn't needed for the `client_state_update` endpoint.

## Problem
When trying to update a call's client state using the SDK's high-level methods:
```python
call.client_state_update(
    client_state="some_state"
)
```
The SDK would raise an error:
```
TypeError: nested_resource_class_methods.<locals>.wrapper.<locals>.update_nested_resource() missing 1 required positional argument: 'nested_id'
```

This is because the PUT operation handler in nested_resource_class_methods required both `id` and `nested_id` parameters, but the client_state_update endpoint only needs the call_control_id.

## Solution
Modified the PUT operation handler in nested_resource_class_methods.py to make the `nested_id` parameter optional:

```python
def update_nested_resource(cls, id, nested_id=None, **params):
    url = getattr(cls, resource_url_method)(id, nested_id)
    return getattr(cls, resource_request_method)("put", url, **params)
```

This change is safe because:
1. client_state_update is the only PUT operation in the entire SDK (verified via codebase search)
2. The URL construction still works correctly with or without nested_id
3. This maintains backward compatibility if future PUT operations need nested_id

## Testing
- Created an outbound call using the SDK
- Successfully updated the call's client state using the high-level SDK method
- Verified the API response shows successful update:
```json
{
  "data": {
    "result": "ok"
  }
}
```

## Files Changed
- `telnyx/api_resources/abstract/nested_resource_class_methods.py`
  - Modified PUT operation handler to make nested_id optional
  - Changed method prefix from update_ to put_ to match SDK patterns

## Related Issues
- DEVREL-1062