### PR TITLE
fix: correct release-please-config.json schema URL

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "packages": {
     ".": {}
   },
-  "$schema": "https://raw.githubusercontent.com/stainless-api/release-please/main/schemas/config.json",
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "bump-minor-pre-major": true,


### PR DESCRIPTION
The `` field was pointing to `stainless-api/release-please` which doesn't exist.

Changed to `googleapis/release-please` — the actual upstream repo for release-please.

Part of the STLC promote cutover for Python SDK.