### PR TITLE
fix: remove silent failure from release-please github-release step

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -136,7 +136,7 @@ jobs:
             --target-branch master \
             --config-file release-please-config.json \
             --manifest-file .release-please-manifest.json \
-            2>&1 || true
+            2>&1
 
       - name: Enable auto-merge on release PRs
         if: github.ref == 'refs/heads/next' && steps.release-pr.outputs.prs_created == 'true'


### PR DESCRIPTION
The `|| true` after the github-release command was silently swallowing tag creation failures.

## Problem
When release-please tried to create the v4.162.0 tag/release, the tag protection ruleset blocked it. The `|| true` swallowed the error, so the workflow reported success but no tag or release was created. This was only discovered when PyPI publish didn't trigger.

## Fix
- Added SDK_WRITE_TOKEN actor to tag ruleset bypass list (already done)
- Removed `|| true` so future failures are visible

## Context
Part of the STLC promote cutover for Python SDK.