### PR TITLE
release: 4.162.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.162.0](https://github.com/team-telnyx/telnyx-python/compare/v4.162.0...v4.162.0) (2026-06-23)
+
+
+### Bug Fixes
+
+* use correct googleapis schema URL in release-please-config.json ([#327](https://github.com/team-telnyx/telnyx-python/issues/327)) ([bf71c7c](https://github.com/team-telnyx/telnyx-python/commit/bf71c7ca8adb4708d0e552c433e9d72327c4da15))
+
 ## [4.162.0](https://github.com/team-telnyx/telnyx-python/compare/v4.157.0...v4.162.0) (2026-06-22)
 
 


### PR DESCRIPTION
Automated Release PR
---


## [4.162.0](https://github.com/team-telnyx/telnyx-python/compare/v4.162.0...v4.162.0) (2026-06-23)


### Bug Fixes

* use correct googleapis schema URL in release-please-config.json ([#327](https://github.com/team-telnyx/telnyx-python/issues/327)) ([bf71c7c](https://github.com/team-telnyx/telnyx-python/commit/bf71c7ca8adb4708d0e552c433e9d72327c4da15))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).