### PR TITLE
fix: check SDK_WRITE_TOKEN instead of RELEASE_PLEASE_TOKEN in release doctor

### DIFF
--- a/bin/check-release-environment
+++ b/bin/check-release-environment
@@ -2,8 +2,8 @@
 
 errors=()
 
-if [ -z "${RELEASE_PLEASE_TOKEN}" ]; then
-  errors+=("The RELEASE_PLEASE_TOKEN secret has not been set. Create a fine-grained GitHub PAT and add it as a repository secret.")
+if [ -z "${SDK_WRITE_TOKEN}" ]; then
+  errors+=("The SDK_WRITE_TOKEN secret has not been set. Add it as a repository secret.")
 fi
 
 lenErrors=${#errors[@]}


### PR DESCRIPTION
## Summary

The `release doctor` check was failing because it checks for `RELEASE_PLEASE_TOKEN` — a secret that doesn't exist and isn't used anywhere in the pipeline.

## Root Cause

`bin/check-release-environment` checks for `RELEASE_PLEASE_TOKEN`, but the actual release workflows (`release-please.yml`, `promote-to-prod.yml`) all use `SDK_WRITE_TOKEN`. This is a Stainless template artifact that was never updated.

## Fix

Update the check to look for `SDK_WRITE_TOKEN` — the token the pipeline actually uses. This is already set as a repo secret and working (it successfully created release PRs).

This will unblock PR #332 (release: 4.163.0) — its `release doctor` check is the only failing gate.
