### PR TITLE
fix: expose SDK_WRITE_TOKEN to release doctor check

### DIFF
--- a/.github/workflows/release-doctor.yml
+++ b/.github/workflows/release-doctor.yml
@@ -15,5 +15,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check release environment
+        env:
+          SDK_WRITE_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
         run: |
           bash ./bin/check-release-environment


### PR DESCRIPTION
## Summary

PR #333 fixed the script to check `SDK_WRITE_TOKEN` but forgot to expose it as an env var in the workflow.

## Root Cause

`check-release-environment` checks `${SDK_WRITE_TOKEN}` in bash, but `release-doctor.yml` never passes the secret as an env var to the script. GitHub secrets aren't automatically available as shell env vars — they must be explicitly mapped via `env:`.

## Fix

Add `env: SDK_WRITE_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}` to the "Check release environment" step.

This is the second half of the fix from PR #333.
