### PR TITLE
fix: use --no-save for release-please install to avoid dirty worktree

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: '20'
 
       - name: Install release-please
-        run: npm install release-please@17
+        run: npm install --no-save release-please@17
 
       - name: Read Release-As version from next branch
         if: github.ref == 'refs/heads/next'


### PR DESCRIPTION
Same fix as telnyx-node PR #446. Without `--no-save`, `npm install release-please@17` modifies package.json, dirtying the worktree and causing subsequent git operations to fail.