### PR TITLE
fix: use -X theirs for next→release-PR merge so staging fixes override stale master code

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -118,7 +118,7 @@ jobs:
           git fetch origin "$PR_BRANCH" next
           git checkout -B "$PR_BRANCH" "origin/$PR_BRANCH"
 
-          if git merge origin/next --no-edit -X ours; then
+          if git merge origin/next --no-edit -X theirs; then
             git push origin "$PR_BRANCH"
             echo "Successfully merged next into release PR branch"
           else


### PR DESCRIPTION
## Problem

The `Merge next code into release PR` step used `git merge origin/next --no-edit -X ours`, which resolves conflicts in favor of the release-please branch (based on master). When staging has a fix that master doesn't have yet (e.g. Parakeet standalone type), the `-X ours` strategy silently keeps master's stale code and overrides the fix from next.

## Fix

Change `-X ours` → `-X theirs` so `next` (which carries staging's generated code) wins conflicts. This ensures the latest generated SDK code always takes precedence over master's potentially-stale version.

This is the same class of issue that caused PR #337's lint failure (unused `TranscriptionEngineParakeetConfigParam` import — master's nested version won over staging's standalone version).