### PR TITLE
fix: use SDK_WRITE_TOKEN in check-release-environment

### DIFF
--- a/bin/check-release-environment
+++ b/bin/check-release-environment
@@ -2,8 +2,8 @@
 
 errors=()
 
-if [ -z "${RELEASE_PLEASE_TOKEN}" ]; then
-  errors+=("The RELEASE_PLEASE_TOKEN secret has not been set. Create a fine-grained GitHub PAT and add it as a repository secret.")
+if [ -z "${SDK_WRITE_TOKEN}" ]; then
+  errors+=("The SDK_WRITE_TOKEN secret has not been set. Add it as a repository secret.")
 fi
 
 lenErrors=${#errors[@]}


### PR DESCRIPTION
## Fix: Release Doctor checks the wrong token

### Problem
`bin/check-release-environment` checks for `RELEASE_PLEASE_TOKEN`, but this secret was never set on the repo. The `release-doctor.yml` workflow already passes `SDK_WRITE_TOKEN` as an env var to the script — the script just checks the wrong variable name.

This causes Release Doctor to **fail on every release-please PR**, blocking auto-merge. This is why v7.5.0 was never published — the release PR couldn't merge through the normal flow.

### Fix
Changed the check from `RELEASE_PLEASE_TOKEN` → `SDK_WRITE_TOKEN`, matching:
- The `release-doctor.yml` workflow (already passes `SDK_WRITE_TOKEN`)
- The `release-please.yml` workflow (already uses `SDK_WRITE_TOKEN` for all operations)
- The PHP SDK's `check-release-environment` (already uses `SDK_WRITE_TOKEN`)
- Ruby SDK's approach (no-op, uses OIDC)

### References
- Ruby SDK: `bin/check-release-environment` is a no-op (OIDC for RubyGems)
- PHP SDK: `bin/check-release-environment` already checks `SDK_WRITE_TOKEN`
- CLI SDK: `bin/check-release-environment` is a no-op (empty errors array)