### PR TITLE
fix: use git reset --hard for tree replacement in release-please.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -143,12 +143,12 @@ jobs:
           done
 
           # Replace entire working tree from next (exact tree, no merge)
-          # git rm handles deletions (files removed in next but still in this branch)
+          # git reset --hard atomically replaces index + working tree from origin/next,
+          # avoiding the empty-index pathspec resolution bug that made
+          # "git rm -rf . && git checkout origin/next -- ." a no-op.
           # git clean removes untracked files (node_modules created by npx release-please)
-          git rm -rf . 2>/dev/null || true
-          git checkout origin/next -- .
+          git reset --hard origin/next
           git clean -fdx
-          git add -A
 
           # Restore version-bump files from the release PR branch
           for f in CHANGELOG.md pyproject.toml src/telnyx/_version.py .release-please-manifest.json; do


### PR DESCRIPTION
## Root Cause

The tree replacement step in `release-please.yml` is a **no-op** — it never syncs `next` code into the release PR.

The sequence:
```bash
git rm -rf . 2>/dev/null || true    # empties the index
git checkout origin/next -- .       # resolves pathspec '.' against empty index → matches nothing
git clean -fdx
git add -A
```

**Git behavior:** `git checkout <tree> -- <pathspec>` resolves the pathspec against the **index**. After `git rm -rf .` empties the index, `.` matches zero paths, so **no files get checked out from `next`**.

The result: `git diff --cached --quiet` succeeds (nothing staged), the step logs `"No changes after syncing next code"`, and the release PR keeps only the 4 version-bump files from release-please.

## Evidence — PR #374

The latest release PR `#374` (release: 4.166.0) has only 4 files:
- `.release-please-manifest.json`
- `CHANGELOG.md`
- `pyproject.toml`
- `src/telnyx/_version.py`

But the staging promote (`ae843cda` on `next`) changed **25 files**, including new KVS storage resources:
- `src/telnyx/resources/storage/kvs/__init__.py` (NEW)
- `src/telnyx/resources/storage/kvs/keys.py` (NEW)
- `src/telnyx/resources/storage/kvs/kvs.py` (NEW)

The `kvs/` directory exists on `next` but is **404 Not Found** on the PR branch. The CI log confirms: `No changes after syncing next code`.

## Fix

Replace the two-step `git rm -rf .` + `git checkout origin/next -- .` with:

```bash
git reset --hard origin/next
git clean -fdx
```

`git reset --hard origin/next` atomically replaces **both** the index and working tree from `origin/next`'s commit — no pathspec resolution against an empty index. The `git clean -fdx` (from PR #369) still removes `node_modules` created by `npx release-please`.

Version-bump files (CHANGELOG.md, pyproject.toml, _version.py, .release-please-manifest.json) are still stashed before the reset and restored after, as before.

## Impact

Every release PR since the tree replacement was introduced has been shipping without the actual SDK code changes from `next`. Only version bumps were being released. This fixes that for all future releases.