### PR TITLE
fix: force-push sync and fix PR URL regex in release-please.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -76,7 +76,8 @@ jobs:
           OUTPUT=$(npx release-please "${ARGS[@]}" 2>&1) || true
           echo "$OUTPUT"
 
-          PR_URL=$(echo "$OUTPUT" | grep -oP 'https://github\.com/[^/]+/[^/]+/pull/\d+' | head -1)
+          # release-please v17 outputs api.github.com URLs (pulls, plural)
+          PR_URL=$(echo "$OUTPUT" | grep -oP 'https://(?:api\.)?github\.com/(?:repos/[^/]+/[^/]+/)?pulls?/\d+' | head -1)
           if [ -n "$PR_URL" ]; then
             PR_NUM=$(echo "$PR_URL" | grep -oP '\d+$')
             echo "pr_number=$PR_NUM" >> "$GITHUB_OUTPUT"
@@ -165,7 +166,7 @@ jobs:
             echo "No changes after syncing next code"
           else
             git commit -m "chore: sync code from next into release PR"
-            git push origin "$PR_BRANCH"
+            git push --force origin "$PR_BRANCH"
             echo "Successfully synced next code into release PR branch (tree replacement)"
           fi
       - name: Run release-please (github-release)


### PR DESCRIPTION
## What

Two follow-up fixes for the tree replacement sync step (after PR #375):

### Fix 1: PR URL regex doesn't match release-please v17 output

release-please v17 outputs:
```
✔ Successfully opened pull request available at url: https://api.github.com/repos/team-telnyx/telnyx-python/pulls/379.
```

But the grep only matched `https://github.com/.../pull/\d+`:
- `api.github.com` not matched (regex requires `github.com`)
- `pulls` (plural) not matched (regex requires `pull/`)
- `/repos/.../pulls/` path not matched

Result: `PR_NUM` was always empty, so the sync step fell back to the label-based branch search, which found stale branches from closed PRs (`release-please--branches--master--changes--next`) instead of the actual open PR branch (`release-please--branches--master`).

**Fix:** Updated regex to match both formats:
```bash
grep -oP 'https://(?:api\.)?github\.com/(?:repos/[^/]+/[^/]+/)?pulls?/\d+'
```

### Fix 2: `git push` rejected as non-fast-forward

`git reset --hard origin/next` (the fix from PR #375) rewrites the branch history — it replaces the entire tree with `next`'s commit, then restores version files on top. This creates a non-fast-forward commit.

The old buggy `git rm -rf .` + `git checkout origin/next -- .` was a no-op, so no commit was ever created and the push was never reached — hiding this issue.

**Fix:** Changed `git push origin "$PR_BRANCH"` to `git push --force origin "$PR_BRANCH"`.

## Evidence

Run 28610892365 failed with:
```
! [rejected] release-please--branches--master--changes--next -> ... (non-fast-forward)
error: failed to push some refs
```

The `git reset --hard` successfully replaced the tree (4 files committed), but the push was rejected.