### PR TITLE
fix(release): handle dirty local release checkout

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -190,7 +190,7 @@ jobs:
 
           BASE_BRANCH="${{ github.event.repository.default_branch }}"
           git fetch origin "$PR_BRANCH" next "$BASE_BRANCH:refs/remotes/origin/release-base"
-          git checkout -B "$PR_BRANCH" "origin/$PR_BRANCH"
+          git checkout -f -B "$PR_BRANCH" "origin/$PR_BRANCH"
 
           # Save version-bump files from the release PR branch (release-please output)
           STASH_DIR=$(mktemp -d)


### PR DESCRIPTION
## Summary\n- force-discard temporary caller-worktree changes left by `release-please --local` before checking out the authoritative remote release branch\n- allow the subsequent `next` tree synchronization to complete on fresh GitHub Actions runners\n\n## Root cause\n`release-please --local` leaves generated changelog and version files modified in the caller checkout after pushing the release branch. A normal `git checkout -B` then refuses to switch branches because those local files would be overwritten.\n\n## Validation\n- `git diff --check`\n- `actionlint -ignore SC2034 .github/workflows/release-please.yml`\n