### PR TITLE
ci: gate Python readiness on exact release PR head

### DIFF
--- a/.github/scripts/release_pr_auto_merge.py
+++ b/.github/scripts/release_pr_auto_merge.py
@@ -395,6 +395,10 @@ class ReleasePRAutoMergeGate:
         expected: Dict[str, str] = dict(self.config.expected_checks)
         for context in live:
             self._require(isinstance(context, str) and context, "invalid live required context")
+            # This gate publishes release-provenance. Waiting for its own future
+            # required context would deadlock readiness forever.
+            if context == "release-provenance":
+                continue
             expected.setdefault(context, "github-actions")
 
         checks = snapshot.get("checks")

--- a/.github/scripts/test_release_pr_auto_merge.py
+++ b/.github/scripts/test_release_pr_auto_merge.py
@@ -294,6 +294,12 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
         client.snapshot["required_contexts"].append("new-policy")
         self.assert_blocked(client, "timed out")
 
+    def test_release_provenance_context_does_not_wait_on_itself(self):
+        client = FixtureClient()
+        client.snapshot["required_contexts"].append("release-provenance")
+        result = self.gate(client).run(415, HEAD, True)
+        self.assertEqual(result["status"], "ready")
+
     def test_pending_check_can_become_successful_before_timeout(self):
         pending = FixtureClient.good_snapshot()
         next(c for c in pending["checks"] if c["name"] == "build").update(

--- a/.github/scripts/test_release_pr_ci_gate.py
+++ b/.github/scripts/test_release_pr_ci_gate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Static safety contracts for the DOT-2061 Python rollout."""
-from pathlib import Path
 import unittest
+from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 

--- a/.github/scripts/test_release_pr_ci_gate.py
+++ b/.github/scripts/test_release_pr_ci_gate.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Static safety contracts for the DOT-2061 Python rollout."""
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class ReleasePRGateWorkflowTests(unittest.TestCase):
+    def test_release_please_pr_runs_every_full_ci_job(self):
+        ci = (ROOT / ".github/workflows/ci.yml").read_text()
+        predicate = "startsWith(github.head_ref, 'release-please--')"
+        self.assertEqual(ci.count(predicate), 3)
+        for name in ("name: lint", "name: build", "name: test"):
+            self.assertIn(name, ci)
+        self.assertIn("python3 .github/scripts/test_release_pr_auto_merge.py -v", ci)
+        self.assertIn("python3 .github/scripts/test_release_pr_ci_gate.py -v", ci)
+
+    def test_readiness_uses_trusted_policy_and_never_merges(self):
+        workflow = (ROOT / ".github/workflows/release-pr-readiness.yml").read_text()
+        self.assertIn("pull_request_target:", workflow)
+        self.assertIn("ref: ${{ github.event.repository.default_branch || 'main' }}", workflow)
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertIn("--expected-head", workflow)
+        self.assertIn("--dry-run", workflow)
+        self.assertNotIn("--merge", workflow)
+        self.assertNotIn("github.event.pull_request.head.sha }}\n          fetch-depth", workflow)
+
+    def test_readiness_publishes_exact_head_status_fail_closed(self):
+        workflow = (ROOT / ".github/workflows/release-pr-readiness.yml").read_text()
+        self.assertIn("context=release-provenance", workflow)
+        self.assertIn("state=pending", workflow)
+        self.assertIn("STATE=failure", workflow)
+        self.assertIn("[ \"$STATE\" = success ]", workflow)
+        self.assertIn("statuses: write", workflow)
+
+    def test_auto_merge_workflow_remains_separate(self):
+        readiness = (ROOT / ".github/workflows/release-pr-readiness.yml").read_text()
+        self.assertNotIn("release-pr-auto-merge.yml", readiness)
+        self.assertNotIn("merge normally", readiness)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
     name: lint
     runs-on: ${{ github.repository == 'stainless-sdks/telnyx-python' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+    if: ((github.event_name == 'push' || github.event.pull_request.head.repo.fork || startsWith(github.head_ref, 'release-please--')) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata'))
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -34,8 +34,13 @@ jobs:
       - name: Run lints
         run: ./scripts/lint
 
+      - name: Validate release gate policy
+        run: |
+          python3 .github/scripts/test_release_pr_auto_merge.py -v
+          python3 .github/scripts/test_release_pr_ci_gate.py -v
+
   build:
-    if: (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+    if: ((github.event_name == 'push' || github.event.pull_request.head.repo.fork || startsWith(github.head_ref, 'release-please--')) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata'))
     timeout-minutes: 10
     name: build
     permissions:
@@ -79,7 +84,7 @@ jobs:
     timeout-minutes: 10
     name: test
     runs-on: ${{ github.repository == 'stainless-sdks/telnyx-python' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork || startsWith(github.head_ref, 'release-please--')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/release-pr-readiness.yml
+++ b/.github/workflows/release-pr-readiness.yml
@@ -1,0 +1,140 @@
+name: Exact-head release PR readiness
+
+on:
+  pull_request_target:
+    branches: [master]
+    types: [opened, reopened, synchronize, ready_for_review, labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Release Please PR number
+        required: true
+        type: number
+      expected_head:
+        description: Exact 40-character PR head SHA
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: read
+  statuses: write
+  actions: read
+
+concurrency:
+  group: release-pr-readiness-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  release-provenance:
+    name: release-provenance
+    runs-on: ubuntu-latest
+    timeout-minutes: 65
+    env:
+      EVENT_NAME: ${{ github.event_name }}
+      EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+      EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      EVENT_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      EVENT_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+      EVENT_TITLE: ${{ github.event.pull_request.title }}
+      INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+      INPUT_EXPECTED_HEAD: ${{ inputs.expected_head }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Resolve immutable candidate
+        id: candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            PR_NUMBER="$INPUT_PR_NUMBER"
+            HEAD_SHA="$INPUT_EXPECTED_HEAD"
+            CANDIDATE=true
+          else
+            PR_NUMBER="$EVENT_PR_NUMBER"
+            HEAD_SHA="$EVENT_HEAD_SHA"
+            if [[ "$EVENT_HEAD_REF" == release-please--* ]] && \
+               [[ "$EVENT_TITLE" == release:\ * ]] && \
+               [ "$EVENT_HEAD_REPOSITORY" = "$GITHUB_REPOSITORY" ]; then
+              CANDIDATE=true
+            else
+              CANDIDATE=false
+            fi
+          fi
+          if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid immutable head SHA" >&2
+            exit 1
+          fi
+          {
+            echo "pr_number=$PR_NUMBER"
+            echo "head_sha=$HEAD_SHA"
+            echo "candidate=$CANDIDATE"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Mark non-release PR as not applicable
+        if: steps.candidate.outputs.candidate == 'false'
+        env:
+          HEAD_SHA: ${{ steps.candidate.outputs.head_sha }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            --method POST \
+            --raw-field state=success \
+            --raw-field context=release-provenance \
+            --raw-field description='Not a Release Please PR; provenance gate not applicable'
+
+      - name: Mark release provenance pending
+        if: steps.candidate.outputs.candidate == 'true'
+        env:
+          HEAD_SHA: ${{ steps.candidate.outputs.head_sha }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            --method POST \
+            --raw-field state=pending \
+            --raw-field context=release-provenance \
+            --raw-field description='Attesting exact release head and immutable lineage'
+
+      # pull_request_target executes trusted default-branch workflow code. Never
+      # checkout or execute the pull-request head in this privileged job.
+      - name: Check out trusted default-branch policy
+        if: steps.candidate.outputs.candidate == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch || 'main' }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Attest exact release head without merging
+        id: attest
+        if: steps.candidate.outputs.candidate == 'true'
+        continue-on-error: true
+        env:
+          MERGE_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
+          PR_NUMBER: ${{ steps.candidate.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.candidate.outputs.head_sha }}
+        run: |
+          python3 .github/scripts/release_pr_auto_merge.py \
+            --pr-number "$PR_NUMBER" \
+            --expected-head "$HEAD_SHA" \
+            --dry-run
+
+      - name: Publish exact-head release provenance result
+        if: always() && steps.candidate.outputs.candidate == 'true'
+        env:
+          HEAD_SHA: ${{ steps.candidate.outputs.head_sha }}
+          OUTCOME: ${{ steps.attest.outcome }}
+        run: |
+          set -euo pipefail
+          if [ "$OUTCOME" = "success" ]; then
+            STATE=success
+            DESCRIPTION='Exact release head, lineage, metadata, and checks are ready'
+          else
+            STATE=failure
+            DESCRIPTION='Exact release readiness attestation failed closed'
+          fi
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            --method POST \
+            --raw-field state="$STATE" \
+            --raw-field context=release-provenance \
+            --raw-field description="$DESCRIPTION"
+          [ "$STATE" = success ]


### PR DESCRIPTION
## Summary
- run complete Python CI on the exact Release Please PR head
- add trusted dry-run exact-head release readiness
- host attestor and workflow-policy tests in normal CI

Phase 1 deliberately retains existing duplicate suites until hosted lifecycle proof.

Linear: DOT-2061