### PR TITLE
fix: retain generated Python release dependencies

### DIFF
--- a/.github/scripts/copy_pyproject_version.py
+++ b/.github/scripts/copy_pyproject_version.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# ruff: noqa: T201
+"""Copy only ``[project].version`` between Telnyx Python pyproject files.
+
+Release Please owns the release version, while the promoted ``next`` tree owns
+all dependencies and build metadata. Overlaying the whole release-branch
+``pyproject.toml`` silently reverts newly generated dependencies.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+SEMVER = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+SECTION = re.compile(r"^\s*\[([^]]+)]\s*(?:#.*)?$")
+VERSION = re.compile(
+    r"^(?P<prefix>\s*version\s*=\s*)(?P<quote>['\"])(?P<value>[^'\"]+)(?P=quote)(?P<suffix>\s*(?:#.*)?)(?P<newline>\r?\n?)$"
+)
+
+
+class OverlayError(ValueError):
+    pass
+
+
+def read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise OverlayError(f"cannot read {path}: {exc}") from exc
+
+
+def project_scalar(text: str, key: str, path: Path) -> str:
+    assignment = re.compile(
+        rf"^\s*{re.escape(key)}\s*=\s*(?P<quote>['\"])(?P<value>[^'\"]+)(?P=quote)\s*(?:#.*)?$"
+    )
+    in_project = False
+    matches: list[str] = []
+    for line in text.splitlines():
+        section = SECTION.match(line)
+        if section:
+            in_project = section.group(1).strip() == "project"
+            continue
+        if in_project:
+            match = assignment.match(line)
+            if match:
+                matches.append(match.group("value"))
+    if len(matches) != 1:
+        raise OverlayError(f"{path}: expected exactly one [project].{key} assignment, found {len(matches)}")
+    return matches[0]
+
+
+def validate(text: str, path: Path) -> str:
+    if project_scalar(text, "name", path) != "telnyx":
+        raise OverlayError(f"{path}: project.name must be 'telnyx'")
+    version = project_scalar(text, "version", path)
+    if not SEMVER.fullmatch(version):
+        raise OverlayError(f"{path}: project.version must be a valid semantic version (X.Y.Z)")
+    return version
+
+
+def replace_project_version(text: str, version: str, path: Path) -> str:
+    lines = text.splitlines(keepends=True)
+    in_project = False
+    matches: list[int] = []
+
+    for index, line in enumerate(lines):
+        section = SECTION.match(line.rstrip("\r\n"))
+        if section:
+            in_project = section.group(1).strip() == "project"
+            continue
+        if in_project and VERSION.match(line):
+            matches.append(index)
+
+    if len(matches) != 1:
+        raise OverlayError(f"{path}: expected exactly one [project].version assignment, found {len(matches)}")
+
+    index = matches[0]
+    match = VERSION.match(lines[index])
+    if match is None:  # defensive: the index was collected using the same expression
+        raise OverlayError(f"{path}: could not parse [project].version assignment")
+    lines[index] = (
+        f"{match.group('prefix')}{match.group('quote')}{version}{match.group('quote')}"
+        f"{match.group('suffix')}{match.group('newline')}"
+    )
+    return "".join(lines)
+
+
+def overlay(source: Path, target: Path) -> None:
+    source_text = read(source)
+    target_text = read(target)
+    version = validate(source_text, source)
+    validate(target_text, target)
+    updated = replace_project_version(target_text, version, target)
+
+    # Validate before replacing the target and require the exact source version.
+    if validate(updated, target) != version:
+        raise OverlayError(f"overlay did not set {target} project.version to {version}")
+
+    target.write_text(updated, encoding="utf-8")
+    print(f"Copied project.version={version} from {source} to {target}; retained target dependencies and metadata")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(f"usage: {argv[0]} SOURCE_PYPROJECT TARGET_PYPROJECT", file=sys.stderr)
+        return 2
+    try:
+        overlay(Path(argv[1]), Path(argv[2]))
+    except OverlayError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.github/scripts/test_copy_pyproject_version.py
+++ b/.github/scripts/test_copy_pyproject_version.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("copy_pyproject_version.py")
+WORKFLOW = SCRIPT.parents[1] / "workflows" / "release-please.yml"
+
+
+def pyproject(*, version: str = "1.2.3", dependency: str = "pynacl >= 1.5, < 2", name: str = "telnyx") -> str:
+    return f'''[build-system]
+requires = ["hatchling"]
+
+[project]
+name = "{name}"
+version = "{version}"
+dependencies = ["httpx"]
+
+[project.optional-dependencies]
+webhooks = ["{dependency}"]
+'''
+
+
+class CopyPyprojectVersionTests(unittest.TestCase):
+    def run_script(self, source: Path, target: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["python3", str(SCRIPT), str(source), str(target)],
+            text=True,
+            capture_output=True,
+        )
+
+    def test_copies_only_project_version_and_preserves_next_dependencies(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "release.toml"
+            target = root / "next.toml"
+            source.write_text(pyproject(version="4.178.0", dependency="standardwebhooks >= 1, < 2"))
+            target.write_text(pyproject(version="4.164.0", dependency="pynacl >= 1.5, < 2"))
+
+            result = self.run_script(source, target)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn('version = "4.178.0"', target.read_text())
+            self.assertIn('webhooks = ["pynacl >= 1.5, < 2"]', target.read_text())
+            self.assertNotIn("standardwebhooks", target.read_text())
+
+    def test_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "release.toml"
+            target = root / "next.toml"
+            source.write_text(pyproject(version="4.178.0"))
+            target.write_text(pyproject(version="4.164.0"))
+
+            first = self.run_script(source, target)
+            after_first = target.read_text()
+            second = self.run_script(source, target)
+
+            self.assertEqual(first.returncode, 0, first.stderr)
+            self.assertEqual(second.returncode, 0, second.stderr)
+            self.assertEqual(target.read_text(), after_first)
+
+    def test_fails_closed_for_wrong_package(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "release.toml"
+            target = root / "next.toml"
+            source.write_text(pyproject(name="not-telnyx"))
+            target.write_text(pyproject())
+            original = target.read_text()
+
+            result = self.run_script(source, target)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("project.name must be 'telnyx'", result.stderr)
+            self.assertEqual(target.read_text(), original)
+
+    def test_fails_closed_for_non_semver_source_version(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "release.toml"
+            target = root / "next.toml"
+            source.write_text(pyproject(version="latest"))
+            target.write_text(pyproject())
+            original = target.read_text()
+
+            result = self.run_script(source, target)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("valid semantic version", result.stderr)
+            self.assertEqual(target.read_text(), original)
+
+    def test_fails_closed_when_project_version_assignment_is_ambiguous(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "release.toml"
+            target = root / "next.toml"
+            source.write_text(pyproject())
+            target.write_text(pyproject().replace('version = "1.2.3"', 'version = "1.2.3"\nversion = "1.2.4"'))
+            original = target.read_text()
+
+            result = self.run_script(source, target)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(target.read_text(), original)
+
+    def test_release_workflow_overlays_version_without_restoring_whole_pyproject(self) -> None:
+        workflow = WORKFLOW.read_text()
+
+        self.assertIn(
+            'RELEASE_FILES=("CHANGELOG.md" "src/telnyx/_version.py" ".release-please-manifest.json")',
+            workflow,
+        )
+        self.assertIn(
+            "for f in CHANGELOG.md src/telnyx/_version.py .release-please-manifest.json; do",
+            workflow,
+        )
+        self.assertEqual(workflow.count("python3 .github/scripts/copy_pyproject_version.py"), 2)
+        self.assertNotIn(
+            "for f in CHANGELOG.md pyproject.toml src/telnyx/_version.py",
+            workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Validate release gate policy
         run: |
+          python3 .github/scripts/test_copy_pyproject_version.py -v
           python3 .github/scripts/test_release_pr_auto_merge.py -v
           python3 .github/scripts/test_release_pr_ci_gate.py -v
           python3 .github/scripts/test_classify_production_ci.py -v

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -78,6 +78,8 @@ jobs:
           # it directly makes old commits reappear and starts CHANGELOG from staging's
           # stale copy. The synthetic commit keeps next's code tree, restores release
           # metadata from the production base, and has exactly one parent: that base.
+          # pyproject.toml is mixed ownership: release-please owns only
+          # [project].version, while next owns dependencies and build metadata.
           BASE_BRANCH="${{ github.event.repository.default_branch }}"
           git fetch origin "$BASE_BRANCH:refs/remotes/origin/release-base" next
           RELEASE_BASE=$(git rev-parse refs/remotes/origin/release-base)
@@ -86,8 +88,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          RELEASE_FILES=("CHANGELOG.md" "pyproject.toml" "src/telnyx/_version.py" ".release-please-manifest.json")
+          RELEASE_FILES=("CHANGELOG.md" "src/telnyx/_version.py" ".release-please-manifest.json")
+          RELEASE_PYPROJECT=$(mktemp)
+          git show refs/remotes/origin/release-base:pyproject.toml > "$RELEASE_PYPROJECT"
           git restore --source=refs/remotes/origin/release-base --staged --worktree -- "${RELEASE_FILES[@]}"
+          python3 .github/scripts/copy_pyproject_version.py "$RELEASE_PYPROJECT" pyproject.toml
+          git add pyproject.toml
           SCAN_TREE=$(git write-tree)
           PROMOTE_SUBJECT=$(git log --format=%s --max-count=50 HEAD \
             | grep -m1 -E '^(feat|fix|chore)(\([^)]*\))?!?: promote from staging ' || true)
@@ -192,9 +198,11 @@ jobs:
           git fetch origin "$PR_BRANCH" next "$BASE_BRANCH:refs/remotes/origin/release-base"
           git checkout -f -B "$PR_BRANCH" "origin/$PR_BRANCH"
 
-          # Save version-bump files from the release PR branch (release-please output)
+          # Save release-please output. Keep pyproject.toml only as the source
+          # for [project].version; next remains authoritative for everything else.
           STASH_DIR=$(mktemp -d)
-          for f in CHANGELOG.md pyproject.toml src/telnyx/_version.py .release-please-manifest.json; do
+          cp pyproject.toml "$STASH_DIR/pyproject.toml"
+          for f in CHANGELOG.md src/telnyx/_version.py .release-please-manifest.json; do
             if [ -f "$f" ]; then
               mkdir -p "$STASH_DIR/$(dirname "$f")"
               cp "$f" "$STASH_DIR/$f"
@@ -209,14 +217,17 @@ jobs:
           git read-tree --reset -u origin/next
           git clean -fdx
 
-          # Restore version-bump files from the release PR branch
-          for f in CHANGELOG.md pyproject.toml src/telnyx/_version.py .release-please-manifest.json; do
+          # Restore whole release-owned files, then overlay only the package
+          # version onto next's pyproject.toml.
+          for f in CHANGELOG.md src/telnyx/_version.py .release-please-manifest.json; do
             if [ -f "$STASH_DIR/$f" ]; then
               mkdir -p "$(dirname "$f")"
               cp "$STASH_DIR/$f" "$f"
               git add "$f"
             fi
           done
+          python3 .github/scripts/copy_pyproject_version.py "$STASH_DIR/pyproject.toml" pyproject.toml
+          git add pyproject.toml
           rm -rf "$STASH_DIR"
 
           # Commit if there are changes


### PR DESCRIPTION
## Summary
- treat `pyproject.toml` as mixed-owned release metadata
- overlay only release-please’s `[project].version` onto the promoted `next` file
- keep generated dependencies and build metadata, including the PyNaCl webhook extra
- fail closed on ambiguous package/version contracts and run the helper in production CI

## Root cause
Release sync restored the entire release-branch `pyproject.toml` from production master. That reverted `next`’s `webhooks = ["pynacl ..."]` back to `standardwebhooks`, while syncing Ed25519 source and a PyNaCl lockfile. Release PR #429 therefore failed lint/import validation.

## Validation
- helper TDD: 6 tests pass
- actual PR #429 → `next` simulation retained `version = "4.178.0"` and `webhooks = ["pynacl >= 1.5, < 2"]`
- `./scripts/lint` passed
- 57 existing release/provenance/PyPI policy tests passed
- actionlint reports only pre-existing SC2034 on the unrelated `attempt` variable