### PR TITLE
fix: recognize release overlay policy in next provenance

### DIFF
--- a/.github/scripts/test_validate_next_provenance.py
+++ b/.github/scripts/test_validate_next_provenance.py
@@ -16,6 +16,14 @@ B = ("100644", "blob", "b" * 40)
 
 
 class PythonNextProvenanceTests(unittest.TestCase):
+    def test_release_version_overlay_helpers_are_production_policy(self):
+        self.assertTrue(
+            {
+                ".github/scripts/copy_pyproject_version.py",
+                ".github/scripts/test_copy_pyproject_version.py",
+            }.issubset(PRODUCTION_POLICY_PATHS)
+        )
+
     def test_generated_tree_change_is_rejected(self):
         with self.assertRaisesRegex(GateError, "src/generated.go"):
             require_only_allowed_changes(

--- a/.github/scripts/validate_next_provenance.py
+++ b/.github/scripts/validate_next_provenance.py
@@ -31,8 +31,10 @@ TreeEntry = Tuple[str, str, str]
 PRODUCTION_POLICY_PATHS = frozenset(
     {
         ".github/scripts/classify_production_ci.py",
+        ".github/scripts/copy_pyproject_version.py",
         ".github/scripts/release_pr_auto_merge.py",
         ".github/scripts/test_classify_production_ci.py",
+        ".github/scripts/test_copy_pyproject_version.py",
         ".github/scripts/test_release_pr_auto_merge.py",
         ".github/scripts/test_release_pr_ci_gate.py",
         ".github/scripts/test_validate_next_provenance.py",


### PR DESCRIPTION
## Root cause
The release version-overlay helper and its test are production-owned files restored during staging promotion, but the `next` provenance gate did not enumerate them as production policy. The exact promoted SDK tree was valid; readiness failed closed on those two newly restored policy paths.

## Fix
- enumerate both version-overlay helper paths in production policy
- add a regression assertion binding them to the policy set

## Validation
- next provenance suite: 7 passed
- version-overlay suite: 6 passed
- full lint/typecheck/import gate passed